### PR TITLE
feat(agents): add Analyst agent (#2)

### DIFF
--- a/seamonster/agents/analyst.md
+++ b/seamonster/agents/analyst.md
@@ -193,7 +193,7 @@ Based on the verdict:
 ```bash
 source ./lib/git-api.sh
 
-sm_add_labels "$SEAMONSTER_ORG" "$REPO" "$ISSUE_NUMBER" '["team/scout"]'
+sm_add_labels "$SEAMONSTER_ORG" "$REPO" "$ISSUE_NUMBER" '["type/proposal"]'
 
 sm_comment "$SEAMONSTER_ORG" "$REPO" "$ISSUE_NUMBER" \
   "**Analyst** — assessment complete. Verdict: **Pursue**.
@@ -212,6 +212,8 @@ sm_comment "$SEAMONSTER_ORG" "$REPO" "$ISSUE_NUMBER" \
 Reason: [brief explanation]. Closing this opportunity.
 
 What would change the calculus: [conditions that would warrant revisiting]."
+
+sm_close_issue "$SEAMONSTER_ORG" "$REPO" "$ISSUE_NUMBER"
 ```
 
 #### If "Needs more data": Request specific research
@@ -227,6 +229,8 @@ sm_comment "$SEAMONSTER_ORG" "$REPO" "$ISSUE_NUMBER" \
 2. [Specific data point needed]
 
 Requesting Scout to gather this information."
+
+sm_add_labels "$SEAMONSTER_ORG" "$REPO" "$ISSUE_NUMBER" '["needs-input", "status/waiting"]'
 ```
 
 ## Comparative Analysis


### PR DESCRIPTION
## Summary

Implements #2. Adds the Analyst agent — the second stage in the ideation pipeline (Scout -> Analyst -> Proposal Writer). The Analyst maps market territory and evaluates viability, producing structured assessments that inform whether an opportunity is worth pursuing.

## Changes

- New file: `seamonster/agents/analyst.md`
  - Frontmatter with name, description (trigger keywords), and tools list (Bash, Read, Glob, Grep, WebSearch, WebFetch)
  - Prime directive: analysis only — never writes code or proposals
  - Full workflow: read Scout findings, research market, produce structured assessment, hand off or close
  - Structured assessment template: competitive landscape, feasibility, effort estimate, risk scoring, revenue potential, verdict
  - Comparative analysis format for evaluating options
  - git-api.sh integration examples for all workflow steps
  - Escalation protocol integration for blocked decisions
  - "What good analysis looks like" calibration section
  - "What you never do" guardrails section
  - Rules section (10 rules)

## Testing

- [ ] Verify frontmatter parses correctly (name, description, tools)
- [ ] Confirm trigger keywords match the Orchestrator routing table entry for Analyst
- [ ] Validate all git-api.sh function calls reference real sm_* functions from lib/git-api.sh
- [ ] Review assessment template for completeness against PROJECT.md Analyst role
- [ ] Check structural consistency with existing agents (builder.md, reviewer.md, orchestrator.md, deployer.md)

## Checklist

- [x] Follows established agent file structure (frontmatter, role, workflow, rules)
- [x] No hardcoded secrets
- [x] Escalation protocol included
- [x] References git-api.sh correctly
- [x] Follows project conventions from CLAUDE.md